### PR TITLE
feat: Add version page and display build info in html root element

### DIFF
--- a/.github/workflows/publish-images.sh
+++ b/.github/workflows/publish-images.sh
@@ -59,8 +59,6 @@ if [ "$GITHUB_EVENT_NAME" == "release" ] & [ -z "$RELEASE_VERSION" ]; then
   exit 1
 fi
 
-export BUILDTIMESTAMP=$(date -Iseconds)
-
 # Get github branch value
 # Value is found on different locations depending on the github event
 if [ -n "$GITHUB_HEAD_REF" ]; then
@@ -76,7 +74,15 @@ then
     # placeholder so docker build is working correctly
     TEMP_TAG="release"
 fi
-docker build --tag "$TEMP_TAG" -f Dockerfile .
+
+export BUILDTIMESTAMP=$(date -Iseconds)
+export CI_COMMIT_SHA=$(git rev-parse HEAD)
+
+docker build \
+    --tag "$TEMP_TAG" \
+    --build-arg BUILDTIMESTAMP=$BUILDTIMESTAMP \
+    --build-arg CI_COMMIT_SHA=$CI_COMMIT_SHA \
+    -f Dockerfile .
 
 # if a pull request is updated
 if [[ "$GITHUB_EVENT_NAME" = "pull_request" ]];

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,3 +1,6 @@
+ARG BUILDTIMESTAMP
+ARG CI_COMMIT_SHA
+
 # Install dependencies only when needed
 FROM node:18-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -12,15 +15,21 @@ RUN npm ci
 
 # Rebuild the source code only when needed
 FROM node:18-alpine AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
-
-COPY . .
+ARG BUILDTIMESTAMP
+ARG CI_COMMIT_SHA
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
+
+ENV NEXT_PUBLIC_BUILDTIMESTAMP ${BUILDTIMESTAMP}
+ENV NEXT_PUBLIC_CI_COMMIT_SHA ${CI_COMMIT_SHA}
+
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+
+COPY . .
 
 # Run Prisma migration
 RUN npm run prisma generate --schema ./repository/db/prisma/schema.prisma
@@ -31,7 +40,13 @@ RUN npm run build
 
 # Production image, copy all the files and run next
 FROM node:18-alpine AS runner
+ARG BUILDTIMESTAMP
+ARG CI_COMMIT_SHA
+
 WORKDIR /app
+
+ENV NEXT_PUBLIC_BUILDTIMESTAMP ${BUILDTIMESTAMP}
+ENV NEXT_PUBLIC_CI_COMMIT_SHA ${CI_COMMIT_SHA}
 
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -43,14 +43,14 @@ FROM node:18-alpine AS runner
 ARG BUILDTIMESTAMP
 ARG CI_COMMIT_SHA
 
-WORKDIR /app
-
 ENV NEXT_PUBLIC_BUILDTIMESTAMP ${BUILDTIMESTAMP}
 ENV NEXT_PUBLIC_CI_COMMIT_SHA ${CI_COMMIT_SHA}
 
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1
+
+WORKDIR /app
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -4,6 +4,7 @@ import { PublicEnvScript } from 'next-runtime-env';
 import { LanguageProvider } from '@inlang/paraglide-next';
 
 import Layout from '@/components/layout/Layout';
+import { clientConfig } from '@/config/client';
 import * as m from '@/src/paraglide/messages.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -15,7 +16,11 @@ const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <LanguageProvider>
-      <html lang="de">
+      <html
+        lang="de"
+        data-buildtimestamp={clientConfig.NEXT_PUBLIC_BUILDTIMESTAMP}
+        data-ci-commit-hash={clientConfig.NEXT_PUBLIC_CI_COMMIT_SHA}
+      >
         <head>
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="theme-color" content="#0067A0" />

--- a/app/app/version/page.tsx
+++ b/app/app/version/page.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+
+import { clientConfig } from '@/config/client';
+
+export default function VersionPage() {
+  return (
+    <Container maxWidth="lg" sx={{ pt: 10 }}>
+      <Typography variant="h4" sx={{ pb: 2 }}>
+        Version Information
+      </Typography>
+      <p>Build timestamp: {clientConfig.NEXT_PUBLIC_BUILDTIMESTAMP}</p>
+      <p>Commmit hash: {clientConfig.NEXT_PUBLIC_CI_COMMIT_SHA}</p>
+    </Container>
+  );
+}

--- a/app/config/client.js
+++ b/app/config/client.js
@@ -32,6 +32,16 @@ const Config = z
         errorMap: () => ({ message: 'NEXT_PUBLIC_APP_INSIGHTS_INSTRUMENTATION_KEY must be set!' }),
       })
       .default(''),
+    NEXT_PUBLIC_BUILDTIMESTAMP: z
+      .string({
+        errorMap: () => ({ message: 'NEXT_PUBLIC_BUILDTIMESTAMP must be set!' }),
+      })
+      .default(''),
+    NEXT_PUBLIC_CI_COMMIT_SHA: z
+      .string({
+        errorMap: () => ({ message: 'NEXT_PUBLIC_CI_COMMIT_SHA must be set!' }),
+      })
+      .default(''),
   })
   .superRefine((values, ctx) => {
     const { NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING, NEXT_PUBLIC_APP_INSIGHTS_INSTRUMENTATION_KEY, STAGE } = values;
@@ -55,6 +65,8 @@ const clientConfig = Config.safeParse({
   NEXT_PUBLIC_VAPID_PUBLIC_KEY: env('NEXT_PUBLIC_VAPID_PUBLIC_KEY'),
   NEXT_PUBLIC_STRAPI_GRAPHQL_ENDPOINT: env('NEXT_PUBLIC_STRAPI_GRAPHQL_ENDPOINT'),
   NEXT_PUBLIC_STRAPI_ENDPOINT: env('NEXT_PUBLIC_STRAPI_ENDPOINT'),
+  NEXT_PUBLIC_BUILDTIMESTAMP: env('NEXT_PUBLIC_BUILDTIMESTAMP'),
+  NEXT_PUBLIC_CI_COMMIT_SHA: env('NEXT_PUBLIC_CI_COMMIT_SHA'),
 });
 
 if (!clientConfig.success) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
     build:
       context: ./app
       args:
+        # used for display an innoverse version
         CI_COMMIT_SHA: "LOCAL"
         BUILDTIMESTAMP: 0
     env_file:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,9 @@ services:
     container_name: innoverse
     build:
       context: ./app
+      args:
+        CI_COMMIT_SHA: "LOCAL"
+        BUILDTIMESTAMP: 0
     env_file:
       - ./app/.env
     environment:

--- a/docs/developer/START_UP_GUIDE.md
+++ b/docs/developer/START_UP_GUIDE.md
@@ -114,10 +114,12 @@ The main focus should here be the `client` report, as we do not use any edge fun
 | REDIS_URL                                    | Y        | -       | Runtime   | Innoverse |
 | NEXTAUTH_URL                                 | Y        | -       | Runtime   | Innoverse |
 | NEWS_FEED_SYNC_SECRET                        | Y        | -       | Runtime   | Innoverse |
-| NEXT_PUBLIC_STRAPI_GRAPHQL_ENDPOINT          | Y        | -       | Buildtime | Innoverse |
-| NEXT_PUBLIC_STRAPI_ENDPOINT                  | Y        | -       | Buildtime | Innoverse |
 | STRAPI_TOKEN                                 | Y        | -       | Runtime   | Innoverse |
 | HTTP_BASIC_AUTH                              | Y        | -       | Runtime   | Innoverse |
+| NEXT_PUBLIC_STRAPI_GRAPHQL_ENDPOINT          | Y        | -       | Buildtime | Innoverse |
+| NEXT_PUBLIC_STRAPI_ENDPOINT                  | Y        | -       | Buildtime | Innoverse |
+| NEXT_PUBLIC_BUILDTIMESTAMP                   | Y        | -       | Buildtime | Innoverse |
+| NEXT_PUBLIC_CI_COMMIT_HASH                   | Y        | -       | Buildtime | Innoverse |
 | POSTGRES_USER                                | N        | -       | Runtime   | Innoverse |
 | POSTGRES_PASSWORD                            | N        | -       | Runtime   | Innoverse |
 | NEXTAUTH_AZURE_CLIENT_ID                     | N(\*)    | -       | Runtime   | Innoverse |


### PR DESCRIPTION
Introduces a version page which displays the `BUILDTIMESTAMP` and `CI_COMMIT_SHA` set during the build.
The respective environment variables are
- `NEXT_PUBLIC_BUILDTIMESTAMP`
- `NEXT_PUBLIC_CI_COMMIT_SHA`

and required at buildtime, but not at runtime

To review:
- Run `npm run dev`, the new variables should be optional
- Run `npm run build`, the variables should be required and should be settable by running `export NEXT_PUBLIC_* <value>` before starting the build
- Run `docker build`, the build args should be required
- Run `docker compose build innoverse`, the build args should be passed automatically