### PR TITLE
Update Start-up Guide and Script

### DIFF
--- a/docs/developer/START_UP_GUIDE.md
+++ b/docs/developer/START_UP_GUIDE.md
@@ -16,7 +16,7 @@ You can find a full list of the environment variables in the [Environment variab
 
 ```bash
 # from project root
-cp ./postgres.env.example ./postgres/.env
+cp ./postgres/.env.example ./postgres/.env
 cp ./app/.env.example ./app/.env # and then fill the missing env vars in /app
 cp ./strapi/.env.example ./strapi/.env # and then fill the missing env vars in /strapi
 ```
@@ -27,7 +27,7 @@ Make sure you have three (3) .env files in total. One (1) in /postgres folder, o
 First start the components:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 then start the InnoVerse app locally

--- a/docs/developer/START_UP_GUIDE.md
+++ b/docs/developer/START_UP_GUIDE.md
@@ -27,10 +27,12 @@ Make sure you have three (3) .env files in total. One (1) in /postgres folder, o
 First start the components:
 
 ```bash
-docker compose up
+sh startDev.sh
 ```
 
-then start the InnoVerse app locally
+This script starts the InnoVerse app, strapi, redis and the database in docker.
+
+For easier local development we suggest starting the InnoVerse app locally:
 
 ```bash
 cd ./app

--- a/startDev.sh
+++ b/startDev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Load the .env file and export the required environment variables
+if [ -f "./app/.env" ]; then
+  export $(grep -E '^(POSTGRES_USER|POSTGRES_PASSWORD)=' ./app/.env | xargs)
+else
+  echo ".env file not found in ./app directory"
+  exit 1
+fi
+
+
+# Check if POSTGRES_USER and POSTGRES_PASSWORD are set
+if [ -z "$POSTGRES_USER" ] || [ -z "$POSTGRES_PASSWORD" ]; then
+  echo "POSTGRES_USER or POSTGRES_PASSWORD not set. Please check your .env file."
+  exit 1
+fi
+
+# Start or shut down the docker compose
+if [ "$1" == "--down" ]; then
+  echo "Stopping Docker Compose..."
+  docker compose down
+else
+  echo "Starting Docker Compose..."
+  docker compose up
+fi

--- a/strapi/.nsprc
+++ b/strapi/.nsprc
@@ -38,5 +38,15 @@
     "active": true,
     "notes": "Ignored since @strapi uses an old version of path-to-regexp",
     "expiry": "2024-10-31"
+  },
+  "1099558": {
+    "active": true,
+    "notes": "Ignored since react-router uses an old version of path-to-regexp",
+    "expiry": "2024-10-31"
+  },
+  "1099561": {
+    "active": true,
+    "notes": "Ignored since react-router uses an old version of path-to-regexp",
+    "expiry": "2024-10-31"
   }
 }


### PR DESCRIPTION
- [x] add fixes to start-up guide
- [x] add startup script that copies the needed env vars POSTGRES_USER & POSTGRES_PASSWORD from the `./app/.env`

**How to test:**
- In main, when running `docker compose up` form scratch (e.g. after previously running `docker compose down`) you should have some errors, because the 2 variables are not set (docker expects them either in the local environment or in the `.env` file in the root directory)
```
WARN[0000] The "POSTGRES_USER" variable is not set. Defaulting to a blank string.
WARN[0000] The "POSTGRES_PASSWORD" variable is not set. Defaulting to a blank string.
```
and `FATAL:  no PostgreSQL user name specified in startup packet`

**Next:**
switch to the current branch and run the `sh startDev.sh` command, this should set the env vars correctly and start the docker-compose too

Closes #38 