### PR TITLE
feat: allow parallel editing and responding to comments (#46)

### DIFF
--- a/app/app/auth/signin/page.tsx
+++ b/app/app/auth/signin/page.tsx
@@ -7,7 +7,9 @@ export default function SignIn() {
   return (
     <>
       <SkeletonIndexPage />
-      <LoginDialog providers={process.env.NODE_ENV === 'production' ? ['azure-ad'] : ['azure-ad', 'gitlab', 'credentials']} />
+      <LoginDialog
+        providers={process.env.NODE_ENV === 'production' ? ['azure-ad'] : ['azure-ad', 'gitlab', 'credentials']}
+      />
     </>
   );
 }

--- a/app/components/collaboration/comments/CollaborationCommentResponseCard.tsx
+++ b/app/components/collaboration/comments/CollaborationCommentResponseCard.tsx
@@ -85,7 +85,7 @@ export function useCollaborationCommentResponseCard(props: CollaborationCommentR
     try {
       await updateProjectCollaborationCommentResponse({ responseId: response.id, updatedText });
       setResponse({ ...response, response: updatedText });
-      interactions.onSubmitEdit();
+      interactions.onSubmit();
     } catch (error) {
       console.error('Error updating collaboration comment:', error);
       errorMessage({ message: m.components_collaboration_comments_collaborationCommentResponseCard_updateError() });

--- a/app/components/common/comments/CommentCard.tsx
+++ b/app/components/common/comments/CommentCard.tsx
@@ -5,7 +5,11 @@ import { User } from '@/common/types';
 import { CommentCardHeaderSecondary } from '@/components/common/CommentCardHeaderSecondary';
 import { CommentFooter } from '@/components/common/comments/CommentFooter';
 import CustomButton from '@/components/common/CustomButton';
-import { useEditingInteractions, useEditingState } from '@/components/common/editing/editing-context';
+import {
+  useEditingInteractions,
+  useEditingState,
+  useRespondingInteractions,
+} from '@/components/common/editing/editing-context';
 import WriteTextCard from '@/components/common/editing/writeText/WriteTextCard';
 import * as m from '@/src/paraglide/messages.js';
 
@@ -33,19 +37,20 @@ export const CommentCard = (props: CommentCardProps) => {
   const { comment, isUpvoted, projectName, enableResponses = false, onUpvoteToggle, onEdit, onDelete } = props;
 
   const state = useEditingState();
-  const interactions = useEditingInteractions();
+  const editingInteractions = useEditingInteractions();
+  const respondingInteractions = useRespondingInteractions();
 
   const updateComment = async (updatedText: string) => {
     if (onEdit) {
       await onEdit(updatedText);
     }
-    interactions.onSubmitEdit();
+    editingInteractions.onSubmit();
   };
 
   return state.isEditing(comment) ? (
     <WriteTextCard
       onSubmit={updateComment}
-      onDiscard={interactions.onCancelEdit}
+      onDiscard={editingInteractions.onCancel}
       defaultValues={{ text: comment.comment }}
       metadata={{ projectName }}
       submitButton={
@@ -70,9 +75,9 @@ export const CommentCard = (props: CommentCardProps) => {
           upvoteCount={comment.upvotedBy.length}
           isUpvoted={isUpvoted}
           onUpvote={onUpvoteToggle}
-          onEdit={() => interactions.onStartEdit(comment)}
+          onEdit={() => editingInteractions.onStart(comment)}
           onDelete={onDelete}
-          onResponse={enableResponses ? () => interactions.onStartResponse(comment) : undefined}
+          onResponse={enableResponses ? () => respondingInteractions.onStart(comment) : undefined}
         />
       }
     />

--- a/app/components/common/comments/WriteCommentResponseCard.tsx
+++ b/app/components/common/comments/WriteCommentResponseCard.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { SxProps } from '@mui/material/styles';
 
-import { useEditingInteractions, useEditingState } from '@/components/common/editing/editing-context';
+import { useRespondingInteractions, useRespondingState } from '@/components/common/editing/editing-context';
 
 import WriteTextCard from '../editing/writeText/WriteTextCard';
 
@@ -16,19 +16,25 @@ interface WriteCommentResponseCardProps {
 
 const WriteCommentResponseCard = ({ comment, projectName, onRespond, sx }: WriteCommentResponseCardProps) => {
   const [disabled, setDisabled] = useState(false);
-  const editingState = useEditingState();
-  const editingInteractions = useEditingInteractions();
+  const respondingState = useRespondingState();
+  const respondingInteractions = useRespondingInteractions();
 
   const handleResponse = async (comment: string) => {
     setDisabled(true);
     await onRespond(comment);
-    editingInteractions.onSubmitResponse();
+    respondingInteractions.onSubmit();
     setDisabled(false);
   };
 
   return (
-    editingState.isResponding(comment) && (
-      <WriteTextCard sx={sx} metadata={{ projectName }} onSubmit={handleResponse} disabled={disabled} />
+    respondingState.isEditing(comment) && (
+      <WriteTextCard
+        sx={sx}
+        metadata={{ projectName }}
+        onSubmit={handleResponse}
+        onDiscard={respondingInteractions.onCancel}
+        disabled={disabled}
+      />
     )
   );
 };

--- a/app/components/common/editing/editing-context.tsx
+++ b/app/components/common/editing/editing-context.tsx
@@ -8,14 +8,11 @@ interface EditingState {
   unsavedChangesDialog: JSX.Element;
   state: {
     isEditing: (item: ItemWithId) => boolean;
-    isResponding: (item: ItemWithId) => boolean;
   };
   interactions: {
-    onStartEdit: (item: ItemWithId) => void;
-    onCancelEdit: ({ isDirty }: { isDirty: boolean }) => void;
-    onSubmitEdit: () => void;
-    onStartResponse: (item: ItemWithId) => void;
-    onSubmitResponse: () => void;
+    onStart: (item: ItemWithId) => void;
+    onCancel: ({ isDirty }: { isDirty: boolean }) => void;
+    onSubmit: () => void;
   };
 }
 
@@ -24,7 +21,6 @@ interface ItemWithId {
 }
 
 interface Interaction {
-  type: 'edit' | 'respond';
   itemId: string;
 }
 
@@ -32,20 +28,24 @@ const defaultState: EditingState = {
   unsavedChangesDialog: <></>,
   state: {
     isEditing: () => false,
-    isResponding: () => false,
   },
   interactions: {
-    onStartEdit: () => {},
-    onCancelEdit: () => {},
-    onSubmitEdit: () => {},
-    onStartResponse: () => {},
-    onSubmitResponse: () => {},
+    onStart: () => {},
+    onCancel: () => {},
+    onSubmit: () => {},
   },
 };
 
 const EditingContext = createContext(defaultState);
+const RespondingContext = createContext(defaultState);
 
-export const EditingContextProvider = ({ children }: PropsWithChildren) => {
+export const EditingContextProvider = ({ children }: PropsWithChildren) => (
+  <EditingContext.Provider value={useEditingContext()}>
+    <RespondingContext.Provider value={useEditingContext()}>{children}</RespondingContext.Provider>
+  </EditingContext.Provider>
+);
+
+function useEditingContext() {
   const [interaction, setInteraction] = useState<Interaction>();
   const [pendingInteraction, setPendingInteraction] = useState<Interaction>();
   const [openUnsavedChangesDialog, setOpenUnsavedChangesDialog] = useState(false);
@@ -62,16 +62,16 @@ export const EditingContextProvider = ({ children }: PropsWithChildren) => {
   }, []);
 
   const initiateInteraction = useCallback(
-    (item: ItemWithId, interactionType: 'edit' | 'respond') => {
-      if (interaction?.type === interactionType && interaction.itemId === item.id) {
+    (item: ItemWithId) => {
+      if (interaction?.itemId === item.id) {
         setInteraction(undefined);
         return;
       }
       if (interaction) {
-        setPendingInteraction({ itemId: item.id, type: interactionType });
+        setPendingInteraction({ itemId: item.id });
         setOpenUnsavedChangesDialog(true);
       } else {
-        setInteraction({ itemId: item.id, type: interactionType });
+        setInteraction({ itemId: item.id });
         dismissDialog();
       }
     },
@@ -111,23 +111,21 @@ export const EditingContextProvider = ({ children }: PropsWithChildren) => {
 
   const contextObject: EditingState = {
     state: {
-      isEditing: (item: ItemWithId) => interaction?.type === 'edit' && interaction.itemId === item.id,
-      isResponding: (item: ItemWithId) => interaction?.type === 'respond' && interaction.itemId === item.id,
+      isEditing: (item: ItemWithId) => interaction?.itemId === item.id,
     },
     interactions: {
-      onStartEdit: (item: ItemWithId) => initiateInteraction(item, 'edit'),
-      onCancelEdit: ({ isDirty }) => tryDiscardOrPrompt({ showPrompt: isDirty ?? true }),
-      onSubmitEdit: finalizeInteraction,
-      onStartResponse: (item: ItemWithId) => initiateInteraction(item, 'respond'),
-      onSubmitResponse: finalizeInteraction,
+      onStart: (item: ItemWithId) => initiateInteraction(item),
+      onCancel: ({ isDirty }) => tryDiscardOrPrompt({ showPrompt: isDirty ?? true }),
+      onSubmit: finalizeInteraction,
     },
     unsavedChangesDialog: dialog,
   };
 
-  return <EditingContext.Provider value={contextObject}>{children}</EditingContext.Provider>;
-};
+  return contextObject;
+}
 
 const useEditing = () => useContext(EditingContext);
+const useResponding = () => useContext(RespondingContext);
 
 export const useEditingState = () => {
   const editing = useEditing();
@@ -142,4 +140,19 @@ export const useEditingInteractions = () => {
 export const useUnsavedEditingChangesDialog = () => {
   const editing = useEditing();
   return editing.unsavedChangesDialog;
+};
+
+export const useRespondingState = () => {
+  const responding = useResponding();
+  return responding.state;
+};
+
+export const useRespondingInteractions = () => {
+  const responding = useResponding();
+  return responding.interactions;
+};
+
+export const useUnsavedRespondingChangesDialog = () => {
+  const responding = useResponding();
+  return responding.unsavedChangesDialog;
 };

--- a/app/components/newsPage/cards/NewsCollabCommentCard.tsx
+++ b/app/components/newsPage/cards/NewsCollabCommentCard.tsx
@@ -14,7 +14,11 @@ import { CommentCardHeader } from '@/components/common/CommentCardHeader';
 import { errorMessage } from '@/components/common/CustomToast';
 import { EditControls } from '@/components/common/editing/controls/EditControls';
 import { ResponseControls } from '@/components/common/editing/controls/ResponseControl';
-import { useEditingInteractions, useEditingState } from '@/components/common/editing/editing-context';
+import {
+  useEditingInteractions,
+  useEditingState,
+  useRespondingInteractions,
+} from '@/components/common/editing/editing-context';
 import { NewsCardControls } from '@/components/newsPage/cards/common/NewsCardControls';
 import { WriteCommentCard } from '@/components/newsPage/cards/common/WriteCommentCard';
 import * as m from '@/src/paraglide/messages.js';
@@ -70,7 +74,8 @@ function useNewsCollabCommentCard(props: NewsCollabCommentCardProps) {
   const [comment, setComment] = useState(item);
 
   const state = useEditingState();
-  const interactions = useEditingInteractions();
+  const editingInteractions = useEditingInteractions();
+  const respondingInteractions = useRespondingInteractions();
   const { user } = useUser();
   const userIsAuthor = comment.author.providerId === user?.providerId;
 
@@ -78,7 +83,7 @@ function useNewsCollabCommentCard(props: NewsCollabCommentCardProps) {
     try {
       await updateProjectCollaborationComment({ commentId: comment.id, updatedText });
       setComment({ ...comment, comment: updatedText });
-      interactions.onSubmitEdit();
+      editingInteractions.onSubmit();
     } catch (error) {
       console.error('Error updating collaboration comment:', error);
       errorMessage({ message: m.components_collaboration_comments_collaborationCommentCard_updateError() });
@@ -108,9 +113,9 @@ function useNewsCollabCommentCard(props: NewsCollabCommentCardProps) {
     question,
     displayEditingControls: userIsAuthor,
     isEditing: state.isEditing(comment),
-    startEditing: () => interactions.onStartEdit(comment),
-    startResponse: () => interactions.onStartResponse(comment),
-    cancelEditing: (params: { isDirty: boolean }) => interactions.onCancelEdit(params),
+    startEditing: () => editingInteractions.onStart(comment),
+    startResponse: () => respondingInteractions.onStart(comment),
+    cancelEditing: editingInteractions.onCancel,
     handleUpdate,
     handleDelete,
   };

--- a/app/components/newsPage/cards/NewsCollabCommentResponseCard.tsx
+++ b/app/components/newsPage/cards/NewsCollabCommentResponseCard.tsx
@@ -33,7 +33,7 @@ export const NewsCollabCommentResponseCard = (props: NewsCollabCommentResponseCa
         updatedAt: response.createdAt,
       }}
       onSubmit={updateResponse}
-      onDiscard={interactions.onCancelEdit}
+      onDiscard={interactions.onCancel}
     />
   ) : (
     <TextCard
@@ -43,7 +43,7 @@ export const NewsCollabCommentResponseCard = (props: NewsCollabCommentResponseCa
       }
       footer={
         <Stack direction={'row'} sx={{ mt: 0 }} style={{ marginTop: '8px', marginLeft: '-8px' }}>
-          {userIsAuthor && <EditControls onEdit={() => interactions.onStartEdit(response)} onDelete={deleteResponse} />}{' '}
+          {userIsAuthor && <EditControls onEdit={() => interactions.onStart(response)} onDelete={deleteResponse} />}{' '}
         </Stack>
       }
       contentSx={{ marginLeft: 4 }}

--- a/app/components/newsPage/cards/NewsCommentCard.tsx
+++ b/app/components/newsPage/cards/NewsCommentCard.tsx
@@ -8,7 +8,11 @@ import { CommentCardHeader } from '@/components/common/CommentCardHeader';
 import { errorMessage } from '@/components/common/CustomToast';
 import { EditControls } from '@/components/common/editing/controls/EditControls';
 import { ResponseControls } from '@/components/common/editing/controls/ResponseControl';
-import { useEditingInteractions, useEditingState } from '@/components/common/editing/editing-context';
+import {
+  useEditingInteractions,
+  useEditingState,
+  useRespondingInteractions,
+} from '@/components/common/editing/editing-context';
 import { TextCard } from '@/components/common/TextCard';
 import { removeUserComment, updateUserComment } from '@/components/newsPage/cards/actions';
 import { WriteCommentCard } from '@/components/newsPage/cards/common/WriteCommentCard';
@@ -57,7 +61,8 @@ const useNewsCommentCard = (props: NewsCommentCardProps) => {
   const { comment, commentType, displayResponseControls, onDelete, onUpdate } = props;
 
   const state = useEditingState();
-  const interactions = useEditingInteractions();
+  const editingInteractions = useEditingInteractions();
+  const respondingInteractions = useRespondingInteractions();
   const { user } = useUser();
 
   const userIsAuthor = user?.providerId === comment.author.providerId;
@@ -80,7 +85,7 @@ const useNewsCommentCard = (props: NewsCommentCardProps) => {
     try {
       await updateUserComment({ commentId: comment.commentId, content: updatedText, commentType });
       onUpdate(updatedText);
-      interactions.onSubmitEdit();
+      editingInteractions.onSubmit();
     } catch (error) {
       console.error('Error updating comment:', error);
       errorMessage({ message: m.components_newsPage_cards_commentCard_error_update() });
@@ -96,9 +101,9 @@ const useNewsCommentCard = (props: NewsCommentCardProps) => {
     displayEditingControls: userIsAuthor,
     displayResponseControls,
     isEditing: state.isEditing(comment),
-    startEdit: () => interactions.onStartEdit(comment),
-    startResponse: () => interactions.onStartResponse(comment),
-    cancelEdit: (params: { isDirty: boolean }) => interactions.onCancelEdit(params),
+    startEdit: () => editingInteractions.onStart(comment),
+    startResponse: () => respondingInteractions.onStart(comment),
+    cancelEdit: editingInteractions.onCancel,
     updateComment: handleUpdate,
     deleteComment: handleDelete,
   };

--- a/app/components/newsPage/cards/NewsPostCard.tsx
+++ b/app/components/newsPage/cards/NewsPostCard.tsx
@@ -10,7 +10,11 @@ import { CommentCardHeader } from '@/components/common/CommentCardHeader';
 import { errorMessage } from '@/components/common/CustomToast';
 import { EditControls } from '@/components/common/editing/controls/EditControls';
 import { ResponseControls } from '@/components/common/editing/controls/ResponseControl';
-import { useEditingInteractions, useEditingState } from '@/components/common/editing/editing-context';
+import {
+  useEditingInteractions,
+  useEditingState,
+  useRespondingInteractions,
+} from '@/components/common/editing/editing-context';
 import { parseStringForLinks } from '@/components/common/LinkString';
 import { NewsCardControls } from '@/components/newsPage/cards/common/NewsCardControls';
 import { WriteCommentCard } from '@/components/newsPage/cards/common/WriteCommentCard';
@@ -28,7 +32,8 @@ function NewsPostCard(props: NewsPostCardProps) {
   const [post, setPost] = useState(props.post);
 
   const state = useEditingState();
-  const interactions = useEditingInteractions();
+  const editingInteractions = useEditingInteractions();
+  const respondingInteractions = useRespondingInteractions();
   const { user } = useUser();
   const userIsAuthor = user?.providerId === post.author?.providerId;
 
@@ -37,7 +42,7 @@ function NewsPostCard(props: NewsPostCardProps) {
       if (user) {
         updatePost({ postId: post.id, content: updatedText, user });
         setPost({ ...post, content: updatedText });
-        interactions.onSubmitEdit();
+        editingInteractions.onSubmit();
       }
     } catch (error) {
       console.error('Error updating post:', error);
@@ -70,7 +75,7 @@ function NewsPostCard(props: NewsPostCardProps) {
         comment: post.content,
       }}
       onSubmit={(updatedText) => handleUpdate(updatedText, user)}
-      onDiscard={interactions.onCancelEdit}
+      onDiscard={editingInteractions.onCancel}
     />
   ) : (
     <>
@@ -81,8 +86,8 @@ function NewsPostCard(props: NewsPostCardProps) {
         </Typography>
       </CardContentWrapper>
       <NewsCardControls>
-        {userIsAuthor && <EditControls onEdit={() => interactions.onStartEdit(post)} onDelete={handleDelete} />}
-        <ResponseControls onResponse={() => interactions.onStartResponse(post)} />
+        {userIsAuthor && <EditControls onEdit={() => editingInteractions.onStart(post)} onDelete={handleDelete} />}
+        <ResponseControls onResponse={() => respondingInteractions.onStart(post)} />
       </NewsCardControls>
     </>
   );

--- a/app/components/newsPage/cards/NewsUpdateCard.tsx
+++ b/app/components/newsPage/cards/NewsUpdateCard.tsx
@@ -5,7 +5,11 @@ import { SeverityLevel } from '@microsoft/applicationinsights-web';
 import { ProjectUpdate } from '@/common/types';
 import { CommentCardHeader } from '@/components/common/CommentCardHeader';
 import { errorMessage } from '@/components/common/CustomToast';
-import { useEditingInteractions, useEditingState } from '@/components/common/editing/editing-context';
+import {
+  useEditingInteractions,
+  useEditingState,
+  useRespondingInteractions,
+} from '@/components/common/editing/editing-context';
 import { UpdateCardContent } from '@/components/common/UpdateCardContent';
 import { UpdateCardActions } from '@/components/newsPage/cards/common/NewsUpdateCardActions';
 import { WriteCommentCard } from '@/components/newsPage/cards/common/WriteCommentCard';
@@ -23,13 +27,14 @@ interface UpdateCardProps {
 export const NewsUpdateCard = (props: UpdateCardProps) => {
   const { update, onUpdate, onDelete, noClamp = false } = props;
   const state = useEditingState();
-  const interactions = useEditingInteractions();
+  const editingInteractions = useEditingInteractions();
+  const respondingInteractions = useRespondingInteractions();
 
   const handleUpdate = async (updatedText: string) => {
     try {
       await updateProjectUpdate({ updateId: update.id, comment: updatedText });
       onUpdate(updatedText);
-      interactions.onSubmitEdit();
+      editingInteractions.onSubmit();
     } catch (error) {
       console.error('Error updating project update:', error);
       errorMessage({ message: m.components_newsPage_cards_newsCard_error_update() });
@@ -55,7 +60,7 @@ export const NewsUpdateCard = (props: UpdateCardProps) => {
   };
 
   return state.isEditing(update) ? (
-    <WriteCommentCard content={update} onSubmit={handleUpdate} onDiscard={interactions.onCancelEdit} />
+    <WriteCommentCard content={update} onSubmit={handleUpdate} onDiscard={editingInteractions.onCancel} />
   ) : (
     <>
       <CommentCardHeader content={update} avatar={{ size: 32 }} />
@@ -63,8 +68,8 @@ export const NewsUpdateCard = (props: UpdateCardProps) => {
       <UpdateCardActions
         update={update}
         onDelete={handleDelete}
-        onEdit={() => interactions.onStartEdit(update)}
-        onResponse={() => interactions.onStartResponse(update)}
+        onEdit={() => editingInteractions.onStart(update)}
+        onResponse={() => respondingInteractions.onStart(update)}
       />
     </>
   );

--- a/app/components/newsPage/threads/CommentThread.tsx
+++ b/app/components/newsPage/threads/CommentThread.tsx
@@ -15,7 +15,7 @@ import theme from '@/styles/theme';
 import { AuthResponse } from '@/utils/auth';
 import { appInsights } from '@/utils/instrumentation/AppInsights';
 
-import { useEditingState } from '../../common/editing/editing-context';
+import { useRespondingState } from '../../common/editing/editing-context';
 
 interface CommentThreadProps<TComment> {
   comment: { id: string; responseCount: number };
@@ -92,7 +92,7 @@ export const CommentThread = <TComment extends ThreadComment>(props: CommentThre
 const useCommentThread = <TComment extends ThreadComment>(props: CommentThreadProps<TComment>) => {
   const { comment, card, disableDivider, indentResponses, fetchResponses, renderResponse, addResponse } = props;
   const [responses, setResponses] = useState<ResponseState<TComment>>({ isVisible: false, isLoading: false });
-  const state = useEditingState();
+  const state = useRespondingState();
 
   const responsesExist = comment.responseCount > 0 || (responses.data?.length ?? 0) > 0;
 
@@ -167,7 +167,7 @@ const useCommentThread = <TComment extends ThreadComment>(props: CommentThreadPr
     responses,
     indentResponses,
     showLoadResponsesButton: !responses.isVisible && !responses.isLoading && comment.responseCount > 0,
-    showDivider: !disableDivider && (responsesExist || state.isResponding(comment)),
+    showDivider: !disableDivider && (responsesExist || state.isEditing(comment)),
     handleResponse,
     deleteResponse,
     updateResponse,


### PR DESCRIPTION
Closes #46.

I assumed that one edit and one response should be allowed in parallel, but not more than one of either. Please let me know if that assumption was wrong.