### PR TITLE
fix: display unsaved changes dialog when responding

### DIFF
--- a/app/components/common/editing/UnsavedChangesDialog.tsx
+++ b/app/components/common/editing/UnsavedChangesDialog.tsx
@@ -11,7 +11,7 @@ import * as m from '@/src/paraglide/messages.js';
 
 import CustomButton from '../CustomButton';
 
-import { useUnsavedEditingChangesDialog } from './editing-context';
+import { useUnsavedChangesDialog } from './editing-context';
 
 interface UnsavedChangesDialogProps {
   open: boolean;
@@ -23,7 +23,7 @@ export const UnsavedEditingChangesDialog = () => {
   // The 'useUnsavedEditingChangesDialog' hook causes this component to rerender
   // whenever a user initiates/discards an edit or response. Isolating this into
   // a separate components can help reduce rerendering overhead.
-  const dialog = useUnsavedEditingChangesDialog();
+  const dialog = useUnsavedChangesDialog();
   return dialog;
 };
 

--- a/app/components/common/editing/editing-context.tsx
+++ b/app/components/common/editing/editing-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
 
 import { UnsavedChangesDialog } from './UnsavedChangesDialog';
 

--- a/app/components/common/editing/editing-context.tsx
+++ b/app/components/common/editing/editing-context.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { createContext, PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
 
 import { UnsavedChangesDialog } from './UnsavedChangesDialog';
 
 interface EditingState {
-  unsavedChangesDialog: JSX.Element;
+  unsavedChangesDialog: {
+    element: JSX.Element;
+    isOpen: boolean;
+  };
   state: {
     isEditing: (item: ItemWithId) => boolean;
   };
@@ -25,7 +28,10 @@ interface Interaction {
 }
 
 const defaultState: EditingState = {
-  unsavedChangesDialog: <></>,
+  unsavedChangesDialog: {
+    element: <></>,
+    isOpen: false,
+  },
   state: {
     isEditing: () => false,
   },
@@ -118,7 +124,10 @@ function useEditingContext() {
       onCancel: ({ isDirty }) => tryDiscardOrPrompt({ showPrompt: isDirty ?? true }),
       onSubmit: finalizeInteraction,
     },
-    unsavedChangesDialog: dialog,
+    unsavedChangesDialog: {
+      element: dialog,
+      isOpen: openUnsavedChangesDialog,
+    },
   };
 
   return contextObject;
@@ -137,11 +146,6 @@ export const useEditingInteractions = () => {
   return editing.interactions;
 };
 
-export const useUnsavedEditingChangesDialog = () => {
-  const editing = useEditing();
-  return editing.unsavedChangesDialog;
-};
-
 export const useRespondingState = () => {
   const responding = useResponding();
   return responding.state;
@@ -152,7 +156,10 @@ export const useRespondingInteractions = () => {
   return responding.interactions;
 };
 
-export const useUnsavedRespondingChangesDialog = () => {
+export const useUnsavedChangesDialog = () => {
+  const editing = useEditing();
   const responding = useResponding();
-  return responding.unsavedChangesDialog;
+  const editingDialog = editing.unsavedChangesDialog;
+  const respondingDialog = responding.unsavedChangesDialog;
+  return editingDialog.isOpen ? editingDialog.element : respondingDialog.element;
 };


### PR DESCRIPTION
Resolves #83 

The unsaved changes dialog for responses was not shown at all. Hence, when clicking on respond on a second comment (when the first response was not finished) nothing happened