### PR TITLE
Docker bugfixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       - ./app/.env
     environment:
       NEXTAUTH_URL: http://localhost:3001
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/app?schema=public
+      DATABASE_URL: postgresql://${POSTGRES_USER:-inno}:${POSTGRES_PASSWORD:-hub}@database:5432/innoverse?schema=public
       NEXT_PUBLIC_STRAPI_GRAPHQL_ENDPOINT: http://strapi:1337/graphql
       NEXT_PUBLIC_STRAPI_ENDPOINT: http://strapi:1337
       REDIS_URL: redis://cache:6379

--- a/strapi/.dockerignore
+++ b/strapi/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Added node_modules to dockerignore in strapi so local modules aren't copied to the container. on mac this would cause the container to break due to native extensions with mismatched platforms.
I also added default database credentials to the docker-compose in case the environment variables aren't set, as they aren't sourced from ./app/env automatically

Closes #51 