### PR TITLE
feat: frontend for dropzone to add images/video

### DIFF
--- a/app/common/types.ts
+++ b/app/common/types.ts
@@ -391,6 +391,7 @@ export type Post = CommonNewsFeedProps & {
   upvotedBy: string[];
   responseCount: number;
   anonymous: boolean;
+  media: string;
 };
 
 export type ImageFormat = {

--- a/app/components/common/form/DropzoneField.tsx
+++ b/app/components/common/form/DropzoneField.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback, useState } from 'react';
+import Dropzone from 'react-dropzone';
+import { Controller } from 'react-hook-form';
+
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+import { FormInputProps } from '@/common/formTypes';
+
+export const DropzoneField = ({ name, control }: FormInputProps) => {
+  const [previewFile, setPreviewFile] = useState<string | null>(null);
+
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    if (acceptedFiles.length > 0) {
+      const file = acceptedFiles[0];
+      const previewUrl = URL.createObjectURL(file);
+      console.log('previewUrl', previewUrl);
+      setPreviewFile(previewUrl);
+      return file;
+    }
+    return null;
+  }, []);
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field: { onChange, onBlur } }) => (
+          <Dropzone
+            onDrop={(acceptedFiles: File[]) => {
+              const file = onDrop(acceptedFiles);
+              if (file) {
+                onChange(file); 
+              }
+            }}
+            accept={{
+              'image/*': [], 
+              'video/*': [], 
+            }}
+            multiple={false} 
+          >
+            {({ getRootProps, getInputProps, isDragActive }) => (
+              <Box
+                {...getRootProps()}
+                sx={{
+                  border: '1px dashed',
+                  borderColor: isDragActive ? 'primary.main' : 'rgba(0, 0, 0, 0.2)',
+                  borderRadius: '4px',
+                  padding: '20px',
+                  marginTop: '10px',
+                  cursor: 'pointer',
+                  height: '100px',
+                  alignItems: 'center',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  color: 'rgba(0, 0, 0, 0.56)',
+                  '&:hover': {
+                    borderColor: 'black',
+                  },
+                }}
+              >
+                <input {...getInputProps()} onBlur={onBlur} />
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexDirection: 'row',
+                    gap: 1,
+                  }}
+                >
+                  <CloudUploadIcon />
+                  <Typography variant="body1" color="rgba(0, 0, 0, 0.56)">
+                    Fotos oder Videos hochladen
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+          </Dropzone>
+        )}
+      />
+
+      {previewFile && (
+        <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          <Box
+            sx={{
+              width: '130px',
+              height: '80px',
+              border: '1px solid rgba(0, 0, 0, 0.1)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              overflow: 'hidden',
+              backgroundColor: 'rgba(0, 0, 0, 0.1)',
+            }}
+          >
+            {previewFile.includes('video') ? (
+              <video controls style={{ maxWidth: '100%', maxHeight: '100%' }}>
+                <source src={previewFile} type="video/mp4" />
+              </video>
+            ) : (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={previewFile} alt="preview" style={{ maxWidth: '100%', maxHeight: '100%' }} />
+            )}
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/app/components/newsPage/addPost/form/actions.ts
+++ b/app/components/newsPage/addPost/form/actions.ts
@@ -21,7 +21,7 @@ export const handlePost = withAuth(async (user: UserSession, body: Omit<PostForm
   if (validatedParams.status === StatusCodes.OK) {
     const author = (await getInnoUserByProviderId(user.providerId)) as User;
     if (author) {
-      const newPost = await addPost({ content: body.content, user, anonymous: body.anonymous });
+      const newPost = await addPost({ content: body.content, user, anonymous: body.anonymous, media: body.media });
       return {
         status: StatusCodes.OK,
         data: {

--- a/app/components/newsPage/addPost/form/formFields.tsx
+++ b/app/components/newsPage/addPost/form/formFields.tsx
@@ -2,6 +2,7 @@ const formFieldNames = {
   CONTENT: 'content',
   PROJECT: 'project',
   ANONYMOUS: 'anonymous',
+  MEDIA: 'media',
 };
 
 export default formFieldNames;

--- a/app/components/newsPage/addPost/form/validationSchema.ts
+++ b/app/components/newsPage/addPost/form/validationSchema.ts
@@ -6,11 +6,13 @@ export const handleUpdateSchema = z.object({
   content: z.string().min(1, required_field),
   project: z.object({ id: z.string().optional(), label: z.string().optional() }).nullable(),
   anonymous: z.boolean().optional(),
+  media: z.string().optional(),
 });
 
 export const handlePostSchema = z.object({
   content: z.string().min(1, required_field),
   anonymous: z.boolean().optional(),
+  media: z.string().optional(),
 });
 
 export type UpdateFormValidationSchema = z.infer<typeof handleUpdateSchema>;

--- a/app/components/newsPage/addUpdate/form/formFields.tsx
+++ b/app/components/newsPage/addUpdate/form/formFields.tsx
@@ -2,6 +2,7 @@ const formFieldNames = {
   COMMENT: 'comment',
   PROJECT: 'project',
   ANONYMOUS: 'anonymous',
+  MEDIA: 'media',
 };
 
 export default formFieldNames;

--- a/app/components/newsPage/cards/common/WriteCommentCard.tsx
+++ b/app/components/newsPage/cards/common/WriteCommentCard.tsx
@@ -7,7 +7,7 @@ import WriteTextCard from '@/components/common/editing/writeText/WriteTextCard';
 import * as m from '@/src/paraglide/messages.js';
 
 interface WriteCommentCardProps {
-  content: { author: User; updatedAt: Date; comment: string; anonymous?: boolean };
+  content: { author: User; updatedAt: Date; comment: string; anonymous?: boolean, media?: string };
   onSubmit: (updatedText: string) => Promise<void>;
   onDiscard: ({ isDirty }: { isDirty: boolean }) => void;
 }

--- a/app/messages/de.json
+++ b/app/messages/de.json
@@ -262,6 +262,8 @@
   "components_newsPage_addPost_form_addPostForm_postCreated": "Neuigkeit wurde erstellt",
   "components_newsPage_addPost_form_addPostForm_createError": "Es ist ein Fehler beim Erstellen der Neuigkeit aufgetreten. Bitte versuchen sie es erneut",
   "components_newsPage_addPost_form_addPostForm_addPost": "Hier kannst du deinen Beitrag hinzufügen …",
+  "components_newsPage_addPost_form_addPostForm_addMedia": "Fotos oder Videos hochladen",
+  "components_newsPage_addPost_form_addPostForm_preview": "Vorschau:",
   "components_newsPage_addPost_form_addPostForm_projectLabel": "Projekt",
   "components_newsPage_addPost_form_addPostForm_anonymousPost": "Anonym posten",
 

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -262,6 +262,8 @@
   "components_newsPage_addPost_form_addPostForm_postCreated": "News has been created",
   "components_newsPage_addPost_form_addPostForm_createError": "An error occurred while creating the news. Please try again",
   "components_newsPage_addPost_form_addPostForm_addPost": "You can add your post here …",
+  "components_newsPage_addPost_form_addPostForm_addMedia": "Upload images or videos",
+  "components_newsPage_addPost_form_addPostForm_preview": "Preview:",
   "components_newsPage_addPost_form_addPostForm_projectLabel": "Project",
   "components_newsPage_addPost_form_addPostForm_anonymousPost": "Post anonymously",
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -45,6 +45,7 @@
         "nookies": "^2.5.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-dropzone": "^14.2.9",
         "react-hook-form": "^7.49.3",
         "react-infinite-scroll-component": "^6.1.0",
         "react-router-dom": "^6.21.3",
@@ -3340,6 +3341,14 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.4.tgz",
+      "integrity": "sha512-2pA6xFIbdTUDCAwjN8nQwI+842VwzbDUXO2IYlpPXQIORgKnavorcr4Ce3rwh+zsNg9zK7QPsdvDj3Lum4WX4w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5151,6 +5160,17 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -7444,6 +7464,22 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.9.tgz",
+      "integrity": "sha512-jRZsMC7h48WONsOLHcmhyn3cRWJoIPQjPApvt/sJVfnYaB3Qltn025AoRTTJaj4WdmmgmLl6tUQg1s0wOhpodQ==",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/app/package.json
+++ b/app/package.json
@@ -55,6 +55,7 @@
     "nookies": "^2.5.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-dropzone": "^14.2.9",
     "react-hook-form": "^7.49.3",
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.21.3",

--- a/app/repository/db/posts.ts
+++ b/app/repository/db/posts.ts
@@ -53,9 +53,9 @@ export async function getPostsFromDbStartingFrom(client: PrismaClient, from: Dat
   }
 }
 
-export async function addPostToDb(client: PrismaClient, content: string, author: string, anonymous: boolean) {
+export async function addPostToDb(client: PrismaClient, content: string, author: string, anonymous: boolean, media: string,) {
   try {
-    return await client.post.create({ data: { author, content, anonymous } });
+    return await client.post.create({ data: { author, content, anonymous, media } });
   } catch (err) {
     const error: InnoPlatformError = dbError(`Add post with by author: ${author}`, err as Error);
     logger.error(error);

--- a/app/repository/db/prisma/migrations/20241028151003_/migration.sql
+++ b/app/repository/db/prisma/migrations/20241028151003_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `media` to the `Post` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "media" TEXT NOT NULL;

--- a/app/repository/db/prisma/schema.prisma
+++ b/app/repository/db/prisma/schema.prisma
@@ -160,6 +160,7 @@ model Post {
   author      String // id of author
   content     String
   anonymous Boolean @default(false)
+  media     String
 }
 
 enum ObjectType {

--- a/app/services/postService.ts
+++ b/app/services/postService.ts
@@ -25,7 +25,7 @@ import { getInnoUserByProviderId } from '@/utils/requests/innoUsers/requests';
 
 const logger = getLogger();
 
-type AddPost = { content: string; user: UserSession; anonymous?: boolean };
+type AddPost = { content: string; user: UserSession; anonymous?: boolean, media?: string };
 
 type UpdatePost = { postId: string; content: string; user: UserSession };
 
@@ -38,8 +38,8 @@ type UpvotePost = { postId: string; user: UserSession };
 
 type DeletePost = { postId: string };
 
-export const addPost = async ({ content, user, anonymous }: AddPost) => {
-  const createdPost = await addPostToDb(dbClient, content, user.providerId, anonymous ?? false);
+export const addPost = async ({ content, user, anonymous, media }: AddPost) => {
+  const createdPost = await addPostToDb(dbClient, content, user.providerId, anonymous ?? false, media);
   await addPostToCache({ ...createdPost, author: user, responseCount: 0 });
   return createdPost;
 };


### PR DESCRIPTION
Implemented the frontend for the dropzone to add images/videos under "add Post". 
Tried to implement the backend, but currently missing most of backend part. 
- Image can be uploaded but is passed as "blob"-object
- Invalid prisma handling
- Preview of image only available in addPostForm, not on Newspage (post)
- currently only one image/video can be uploaded


