### PR TITLE
News Feed Search: Add min length to the search field

### DIFF
--- a/app/app/contexts/news-feed-context.tsx
+++ b/app/app/contexts/news-feed-context.tsx
@@ -269,7 +269,9 @@ export const NewsFeedContextProvider = ({ children, ...props }: NewsFeedContextP
     const page = 1;
     setFilters(filters);
     setPageNumber(page);
-    refetchFeed({ page, filters });
+    if (filters.searchString.length !== 1) {
+      refetchFeed({ page, filters });
+    }
   };
 
   const contextObject: NewsFeedContextInterface = {

--- a/app/app/contexts/news-feed-highlight-context.tsx
+++ b/app/app/contexts/news-feed-highlight-context.tsx
@@ -16,7 +16,9 @@ export function NewsFeedHighlightContextProvider(props: PropsWithChildren) {
 
   useEffect(
     function updateNewsFeedSearchTerm() {
-      setHighlightString(filters.searchString);
+      if (filters.searchString.length !== 1) {
+        setHighlightString(filters.searchString);
+      }
     },
     [filters.searchString],
   );

--- a/app/components/newsFeed/NewsFeedSearchFilter.tsx
+++ b/app/components/newsFeed/NewsFeedSearchFilter.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { Search } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -81,6 +82,11 @@ export default function NewsFeedSearchFilter(props: NewsFeedSearchFilterProps) {
             'aria-label': 'Search field',
           }}
         />
+        {inputValue.length === 1 && (
+          <FormHelperText sx={{ color: 'formText.main' }}>
+            {m.components_newsFeed_newsFeedSearchFilter_searchField_minLength()}
+          </FormHelperText>
+        )}
       </FormControl>
     </Box>
   );

--- a/app/messages/de.json
+++ b/app/messages/de.json
@@ -103,7 +103,7 @@
   "components_common_editing_confirmDeleteDialog_deletePost": "Möchtest du diesen Beitrag löschen?",
   "components_common_editing_confirmDeleteDialog_cancel": "Abbrechen",
   "components_common_editing_confirmDeleteDialog_delete": "Löschen",
-  
+
   "components_common_editing_unsavedChangesDialog_edit": "Bearbeitung",
   "components_common_editing_unsavedChangesDialog_throw": "Möchtest du diese Bearbeitung verwerfen?",
   "components_common_editing_unsavedChangesDialog_cancel": "Abbrechen",
@@ -237,6 +237,7 @@
   "components_newsFeed_newsFeedContainer_filter": "Filter",
 
   "components_newsFeed_newsFeedSearchFilter_search": "Suche",
+  "components_newsFeed_newsFeedSearchFilter_searchField_minLength": "Geben Sie mindestens 2 Zeichen ein",
 
   "components_newsFeed_newsFeedTypeFilter_comments": "Kommentare",
   "components_newsFeed_newsFeedTypeFilter_events": "Events",

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -237,6 +237,7 @@
   "components_newsFeed_newsFeedContainer_filter": "Filter",
 
   "components_newsFeed_newsFeedSearchFilter_search": "Search",
+  "components_newsFeed_newsFeedSearchFilter_searchField_minLength": "Enter at least 2 characters",
 
   "components_newsFeed_newsFeedTypeFilter_comments": "Comments",
   "components_newsFeed_newsFeedTypeFilter_events": "Events",

--- a/app/styles/palette.ts
+++ b/app/styles/palette.ts
@@ -4,6 +4,7 @@ interface DefaultPaletteOptions extends PaletteOptions {
   primary?: SimplePaletteColorOptions;
   secondary?: SimplePaletteColorOptions;
   statistics?: SimplePaletteColorOptions;
+  formText?: SimplePaletteColorOptions;
 }
 
 const palette: DefaultPaletteOptions = {
@@ -57,6 +58,9 @@ const palette: DefaultPaletteOptions = {
     main: '#B7F9AA',
     light: '#ECFDED',
     dark: '#EBEBEB',
+  },
+  formText: {
+    main: '#B7F9AA',
   },
 };
 


### PR DESCRIPTION
Closes #120 

Due to configuration of Redisearch, the minimum number of characters allowed for prefix queries (used for searching the cache) is set to 2 by default. According to the [documentation](https://redis.io/docs/latest/develop/interact/search-and-query/basic-constructs/configuration-parameters/#minprefix) setting it to 1 can hurt performance. 

To fix the bug, the form helper text was added to a search field - "Enter at least 2 characters".

