### PR TITLE
Limit comment levels to 2 for new comments

### DIFF
--- a/app/components/newsPage/threads/NewsCommentThread.tsx
+++ b/app/components/newsPage/threads/NewsCommentThread.tsx
@@ -56,7 +56,7 @@ export const NewsCommentThread = (props: NewsCommentThreadProps) => {
       <NewsCommentCard
         comment={comment}
         objectType={props.commentType}
-        displayResponseControls={level < 3}
+        displayResponseControls={level < 2}
         onDelete={props.onDelete}
         onUpdate={updateComment}
       />


### PR DESCRIPTION
- [x] limit comment levels to 2 (this applies for writing new comments)
- [x] for existing comments -> 3rd level will still be shown if it exists, did not want to modify this since this means some comments will get lost. What do you think @pecirep @andrea-smiesna ?

Pipeline will pass after merging #173 (hopefully)

Closes #170 
