### PR TITLE
Bug: News are not sorted by updatedAt

### DIFF
--- a/app/utils/newsFeed/redis/mappings.ts
+++ b/app/utils/newsFeed/redis/mappings.ts
@@ -60,7 +60,7 @@ export const mapSurveyQuestionToRedisNewsFeedEntry = (
   item.followedBy = mapUserImagesToRelativeUrls(item.followedBy ?? []);
 
   return {
-    updatedAt: getUnixTimestamp(new Date(surveyQuestion.updatedAt)),
+    updatedAt: item.updatedAt,
     item: item,
     type: NewsType.SURVEY_QUESTION,
     search: escapeRedisTextSeparators(item.question || ''),
@@ -86,7 +86,7 @@ export const mapProjectToRedisNewsFeedEntry = (
   item.followedBy = mapUserImagesToRelativeUrls(item.followedBy ?? []);
 
   return {
-    updatedAt: getUnixTimestamp(new Date(item.updatedAt)),
+    updatedAt: item.updatedAt,
     item: item,
     type: NewsType.PROJECT,
     search: escapeRedisTextSeparators(
@@ -112,7 +112,7 @@ export const mapUpdateToRedisNewsFeedEntry = (
   item.followedBy = mapUserImagesToRelativeUrls(item.followedBy ?? []);
 
   return {
-    updatedAt: getUnixTimestamp(new Date(update.updatedAt)),
+    updatedAt: item.updatedAt,
     item: item,
     type: NewsType.UPDATE,
     search: escapeRedisTextSeparators((item.comment || '') + ' ' + (item.title || '')),
@@ -137,7 +137,7 @@ export const mapEventToRedisNewsFeedEntry = async (
   item.followedBy = mapUserImagesToRelativeUrls(item.followedBy ?? []);
 
   return {
-    updatedAt: getUnixTimestamp(new Date(item.updatedAt)),
+    updatedAt: item.updatedAt,
     item: item,
     type: NewsType.EVENT,
     search: escapeRedisTextSeparators(
@@ -163,7 +163,7 @@ export const mapCollaborationQuestionToRedisNewsFeedEntry = (
   item.followedBy = mapUserImagesToRelativeUrls(item.followedBy ?? []);
 
   return {
-    updatedAt: getUnixTimestamp(new Date(item.updatedAt)),
+    updatedAt: item.updatedAt,
     item: item,
     type: NewsType.COLLABORATION_QUESTION,
     search: escapeRedisTextSeparators((item.title || '') + ' ' + (item.description || '')),

--- a/app/utils/requests/updates/requests.ts
+++ b/app/utils/requests/updates/requests.ts
@@ -225,7 +225,7 @@ export const getUpdateWithReactions = withAuth(async (user: UserSession, body: {
     status: 200,
     data: {
       ...body.update,
-      updatedAt: getUnixTimestamp(new Date(body.update.updatedAt)),
+      updatedAt: getUnixTimestamp(body.update.updatedAt),
       reactions,
       followedByUser: followedByIds.some((followerId) => followerId === user.providerId),
     },


### PR DESCRIPTION
Closes #188 

Fixed the `updatedAt` attribute in the news items.
Previously the `updatedAt` year was 1970 (unix epoch) in the Redis cache.

<img width="221" alt="Screenshot 2025-03-14 at 17 27 04" src="https://github.com/user-attachments/assets/a7131e0c-85d0-485d-a6ee-19fe947aaa48" />
