### PR TITLE
Bug: File is not defined in the production

### DIFF
--- a/app/components/common/form/ImageDropzoneField.tsx
+++ b/app/components/common/form/ImageDropzoneField.tsx
@@ -17,18 +17,19 @@ import { bytesToMegabytes } from '@/utils/helpers';
 import ImagePreview from './ImagePreview';
 
 interface ImageDropzoneFieldProps extends FormInputProps {
-  setValue: (name: any, value: File | null, options?: { shouldDirty: boolean }) => void;
+  setValue: (name: any, value: Blob | null, options?: { shouldDirty: boolean }) => void;
 }
 
 export const ImageDropzoneField = ({ name, control, setValue }: ImageDropzoneFieldProps) => {
   const [file, setFile] = useState<string | null>();
 
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
+    (acceptedFiles: Blob[]) => {
       if (acceptedFiles.length > 0) {
         const file = acceptedFiles[0];
-        setFile(URL.createObjectURL(file));
-        setValue(name, file, { shouldDirty: true });
+        const blobFile = new Blob([file], { type: file.type });
+        setFile(URL.createObjectURL(blobFile));
+        setValue(name, blobFile, { shouldDirty: true });
       }
     },
 
@@ -40,7 +41,7 @@ export const ImageDropzoneField = ({ name, control, setValue }: ImageDropzoneFie
     setValue(name, null, { shouldDirty: true });
   };
 
-  const fileValidator = (file: File) => {
+  const fileValidator = (file: Blob) => {
     if (bytesToMegabytes(file.size) > clientConfig.NEXT_PUBLIC_BODY_SIZE_LIMIT) {
       return {
         code: 'invalid-file-size',
@@ -57,7 +58,7 @@ export const ImageDropzoneField = ({ name, control, setValue }: ImageDropzoneFie
       render={({ field: { onBlur, value } }) => (
         <>
           <Dropzone
-            onDrop={async (acceptedFiles: File[]) => {
+            onDrop={async (acceptedFiles) => {
               onDrop(acceptedFiles);
             }}
             validator={fileValidator}

--- a/app/components/userProfile/validationSchema.ts
+++ b/app/components/userProfile/validationSchema.ts
@@ -22,7 +22,7 @@ export const handleUpdateUserSessionForm = userSessionSchemaForm.extend({
   image: z.union([
     z.null(),
     z.string(),
-    z.instanceof(File).refine((file) => bytesToMegabytes(file.size) < MAX_FILE_SIZE, invalid_file_size(MAX_FILE_SIZE)),
+    z.instanceof(Blob).refine((file) => bytesToMegabytes(file.size) < MAX_FILE_SIZE, invalid_file_size(MAX_FILE_SIZE)),
   ]),
 });
 

--- a/app/package.json
+++ b/app/package.json
@@ -67,6 +67,7 @@
     "sharp": "^0.33.5",
     "slick-carousel": "^1.8.1",
     "swr": "^2.2.5",
+    "undici": "^7.6.0",
     "usehooks-ts": "^3.1.0",
     "web-push": "^3.6.7",
     "winston": "^3.17.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       swr:
         specifier: ^2.2.5
         version: 2.3.0(react@18.3.1)
+      undici:
+        specifier: ^7.6.0
+        version: 7.6.0
       usehooks-ts:
         specifier: ^3.1.0
         version: 3.1.0(react@18.3.1)
@@ -4341,6 +4344,11 @@ packages:
     resolution:
       { integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw== }
 
+  undici@7.6.0:
+    resolution:
+      { integrity: sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA== }
+    engines: { node: '>=20.18.1' }
+
   universal-github-app-jwt@1.2.0:
     resolution:
       { integrity: sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g== }
@@ -8332,6 +8340,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.19.8: {}
+
+  undici@7.6.0: {}
 
   universal-github-app-jwt@1.2.0:
     dependencies:

--- a/app/utils/requests/innoUsers/requests.ts
+++ b/app/utils/requests/innoUsers/requests.ts
@@ -21,6 +21,7 @@ import {
   GetInnoUsersByProviderIdsQuery,
 } from '@/utils/requests/innoUsers/queries';
 import strapiGraphQLFetcher from '@/utils/requests/strapiGraphQLFetcher';
+import { FormData, request } from 'undici';
 
 const logger = getLogger();
 
@@ -250,7 +251,7 @@ async function uploadImage(imageUrl: string, fileName: string) {
       formData.append('files', myBlob, fileName);
       formData.append('ref', 'api::event.event');
       formData.append('field', 'image');
-      return await fetch(`${clientConfig.NEXT_PUBLIC_STRAPI_ENDPOINT}/api/upload`, {
+      return await request(`${clientConfig.NEXT_PUBLIC_STRAPI_ENDPOINT}/api/upload`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${serverConfig.STRAPI_TOKEN}`,
@@ -262,7 +263,7 @@ async function uploadImage(imageUrl: string, fileName: string) {
           throw new Error('Error while uploading image');
         })
         .then((response) => {
-          return response.json();
+          return response.body.json();
         })
         .then((result) => {
           return result as UploadImageResponse[];
@@ -327,7 +328,7 @@ export async function uploadFileImage(image: Blob, fileName: string) {
   formData.append('ref', 'api::event.event');
   formData.append('field', 'image');
 
-  return await fetch(`${clientConfig.NEXT_PUBLIC_STRAPI_ENDPOINT}/api/upload`, {
+  return await request(`${clientConfig.NEXT_PUBLIC_STRAPI_ENDPOINT}/api/upload`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${serverConfig.STRAPI_TOKEN}`,
@@ -339,7 +340,7 @@ export async function uploadFileImage(image: Blob, fileName: string) {
       throw new Error('Error while uploading image');
     })
     .then((response) => {
-      return response.json();
+      return response.body.json();
     })
     .then((result) => {
       return result as UploadImageResponse[];

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1036,11 +1036,11 @@ export interface PluginUploadFolder extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
+    children: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.folder'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     files: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.file'>;
-    children: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.folder'>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',


### PR DESCRIPTION
The type "File" is used for the file upload. Since the "File" type from "node:buffer" is a File API and can't be in the production (or in the container), the type was changed to "Blob".
The "undici" lib was added (request method) since the built-in fetch doesn't work when uploading the file to Strapi.

How to test locally:
* run the frontend in the container
* update the profile avatar
* the file should be successfully uploaded to Strapi