### PR TITLE
Profile: Pass the image as base64 to the server action

### DIFF
--- a/app/common/types.ts
+++ b/app/common/types.ts
@@ -337,7 +337,7 @@ export type UpdateInnoUser = {
   role?: string;
   department?: string;
   oldImageId?: string;
-  image: FormData;
+  image?: string | null;
   avatarId?: string | null;
 };
 

--- a/app/components/common/form/ImageDropzoneField.tsx
+++ b/app/components/common/form/ImageDropzoneField.tsx
@@ -27,9 +27,8 @@ export const ImageDropzoneField = ({ name, control, setValue }: ImageDropzoneFie
     (acceptedFiles: Blob[]) => {
       if (acceptedFiles.length > 0) {
         const file = acceptedFiles[0];
-        const blobFile = new Blob([file], { type: file.type });
-        setFile(URL.createObjectURL(blobFile));
-        setValue(name, blobFile, { shouldDirty: true });
+        setFile(URL.createObjectURL(file));
+        setValue(name, file, { shouldDirty: true });
       }
     },
 

--- a/app/components/userProfile/UserInfo.tsx
+++ b/app/components/userProfile/UserInfo.tsx
@@ -15,6 +15,7 @@ import Typography from '@mui/material/Typography';
 import { useUser } from '@/app/contexts/user-context';
 import { UserSession } from '@/common/types';
 import * as m from '@/src/paraglide/messages.js';
+import { blobToBase64 } from '@/utils/helpers';
 
 import { errorMessage, successMessage } from '../common/CustomToast';
 import { ImageDropzoneField } from '../common/form/ImageDropzoneField';
@@ -56,15 +57,13 @@ export default function UserInfo() {
 
   const onSubmit: SubmitHandler<UserSessionFormValidationSchema> = async (submitData) => {
     const { image, ...userData } = submitData;
-    const formData = new FormData();
-    if (image !== null) {
-      formData.append('image', image);
-    }
+    const userImage = image instanceof Blob ? await blobToBase64(image) : null;
 
     const { data: updatedUser, status } = await updateUserProfile({
       role: userData.role,
       department: userData.department,
-      image: formData,
+      // Include the image in the request only if it's null or a Blob, indicating it has been modified
+      ...(typeof image !== 'string' && { image: userImage }),
     });
 
     if (status === StatusCodes.OK) {

--- a/app/components/userProfile/validationSchema.ts
+++ b/app/components/userProfile/validationSchema.ts
@@ -27,7 +27,7 @@ export const handleUpdateUserSessionForm = userSessionSchemaForm.extend({
 });
 
 export const handleUpdateUserSession = userSessionSchema.extend({
-  image: z.instanceof(FormData),
+  image: z.string().nullable().optional(),
 });
 
 export type UserSessionFormValidationSchema = z.infer<typeof handleUpdateUserSessionForm>;

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -189,3 +189,34 @@ export function bytesToMegabytes(bytes: number | string): number {
   const bytesInMegabyte = 1024 * 1024;
   return bytesNumber / bytesInMegabyte;
 }
+
+export const blobToBase64 = (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(blob);
+    reader.onloadend = () => {
+      const base64String = reader.result?.toString();
+      resolve(base64String || '');
+    };
+    reader.onerror = reject;
+  });
+};
+
+export const base64ToBlob = async (base64String: string): Promise<Blob> => {
+  return await fetch(base64String)
+    .catch((e) => {
+      throw new Error('Error while fetching the base64 image:', e);
+    })
+    .then((response) => {
+      return response.blob();
+    });
+};
+
+export const isBase64String = (str: string): boolean => {
+  try {
+    const split = str.split(',')[1];
+    return btoa(atob(split)) === split;
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
To prevent the request from being blocked by the firewall (due to the $param variable in the request body), convert the FormData to a base64 string instead.