### PR TITLE
Bug: Change the body in upload request, update delete id of the image

### DIFF
--- a/app/components/common/CommentCardHeader.tsx
+++ b/app/components/common/CommentCardHeader.tsx
@@ -57,7 +57,7 @@ export const CommentCardHeader = ({ content, avatar }: CommentCardHeaderProps) =
       }
       subheader={
         author && (
-          <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: '14px', ml: '16px' }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: '14px' }}>
             {author.role}
           </Typography>
         )

--- a/app/utils/requests/innoUsers/mappings.ts
+++ b/app/utils/requests/innoUsers/mappings.ts
@@ -26,7 +26,8 @@ export function mapToUser(userData: ResultOf<typeof InnoUserFragment | null>): U
     email: userData.email ?? undefined,
     providerId: userData.providerId ?? undefined,
     image: mapToAvatarUrl(userData.avatar),
-    imageId: userData.avatar?.documentId,
+    // Upload API expects legacy integer ID; fails with Strapi 5's new documentId
+    imageId: userData.avatar?.id,
   };
 }
 

--- a/app/utils/requests/innoUsers/mutations.ts
+++ b/app/utils/requests/innoUsers/mutations.ts
@@ -34,6 +34,7 @@ export const CreateInnoUserMutation = graphql(`
       email
       username
       avatar {
+        id
         documentId
         formats
         url
@@ -102,6 +103,7 @@ export const UpdateInnoUserUsernameMutation = graphql(`
       department
       email
       avatar {
+        id
         documentId
         formats
         url

--- a/app/utils/requests/innoUsers/queries.ts
+++ b/app/utils/requests/innoUsers/queries.ts
@@ -11,6 +11,7 @@ export const InnoUserFragment = graphql(`
     department
     email
     avatar {
+      id
       documentId
       url
       formats


### PR DESCRIPTION
- [x] add the url `/api/auth/session` as a custom rule in the WAF policy
- [x] change the body passed to update user request (do not pass the image)
- [x] change the imageId from "documentId" to "id" since it's not yet supported in strapi in DELETE request (/upload/files)