### PR TITLE
fix: disable submit button on empty comment while editing

### DIFF
--- a/app/components/common/comments/CommentCard.tsx
+++ b/app/components/common/comments/CommentCard.tsx
@@ -64,17 +64,7 @@ export const CommentCard = (props: CommentCardProps) => {
       onDiscard={editingInteractions.onCancel}
       defaultValues={{ text: comment.text }}
       metadata={{ projectName }}
-      submitButton={
-        <CustomButton
-          themeVariant="secondary"
-          sx={{ mr: 0 }}
-          style={{ marginRight: 0 }}
-          startIcon={<CheckIcon style={{ marginRight: 0 }} sx={{ ml: 1, pr: 0 }} />}
-          endIcon={<></>}
-        >
-          {m.components_common_comments_commentCard_done()}
-        </CustomButton>
-      }
+      getSubmitButton={getSubmitButton}
     />
   ) : (
     <TextCard
@@ -92,5 +82,20 @@ export const CommentCard = (props: CommentCardProps) => {
         />
       }
     />
+  );
+};
+
+const getSubmitButton = (disabled: boolean) => {
+  return (
+    <CustomButton
+      themeVariant="secondary"
+      sx={{ mr: 0 }}
+      style={{ marginRight: 0 }}
+      disabled={disabled}
+      startIcon={<CheckIcon style={{ marginRight: 0 }} sx={{ ml: 1, pr: 0 }} />}
+      endIcon={<></>}
+    >
+      {m.components_common_comments_commentCard_done()}
+    </CustomButton>
   );
 };

--- a/app/components/common/editing/writeText/WriteTextCard.tsx
+++ b/app/components/common/editing/writeText/WriteTextCard.tsx
@@ -39,7 +39,7 @@ interface WriteTextCardProps {
     projectName?: string;
   };
   avatar?: UserAvatarProps;
-  submitButton?: React.ReactNode;
+  getSubmitButton?: (disabled: boolean) => JSX.Element;
   disableAvatar?: boolean;
   disabled?: boolean;
   sx?: SxProps;
@@ -53,7 +53,7 @@ const WriteTextCard = ({
   metadata,
   onSubmit,
   onDiscard,
-  submitButton,
+  getSubmitButton,
   defaultValues,
   disableAvatar = false,
   disabled = false,
@@ -146,7 +146,9 @@ const WriteTextCard = ({
             </IconButton>
           ) : (
             <div onClick={form.handleSubmit(submit)}>
-              {submitButton ?? (
+              {getSubmitButton ? (
+                getSubmitButton(!formState.isValid)
+              ) : (
                 <InteractionButton
                   projectName={metadata?.projectName}
                   interactionType={InteractionType.COMMENT_SEND}

--- a/app/components/newsPage/cards/common/WriteCommentCard.tsx
+++ b/app/components/newsPage/cards/common/WriteCommentCard.tsx
@@ -22,18 +22,23 @@ export const WriteCommentCard = ({ content, onSubmit, onDiscard }: WriteCommentC
         defaultValues={{ text: content.text }}
         disableAvatar
         sx={{ mt: 2 }}
-        submitButton={
-          <CustomButton
-            themeVariant="secondary"
-            sx={{ mr: 0 }}
-            style={{ marginRight: 0 }}
-            startIcon={<CheckIcon style={{ marginRight: 0 }} sx={{ ml: 1, pr: 0 }} />}
-            endIcon={<></>}
-          >
-            {m.components_newsPage_cards_common_writeCommentCard_done()}
-          </CustomButton>
-        }
+        getSubmitButton={getSubmitButton}
       />
     </>
+  );
+};
+
+const getSubmitButton = (disabled: boolean) => {
+  return (
+    <CustomButton
+      themeVariant="secondary"
+      sx={{ mr: 0 }}
+      style={{ marginRight: 0 }}
+      disabled={disabled}
+      startIcon={<CheckIcon style={{ marginRight: 0 }} sx={{ ml: 1, pr: 0 }} />}
+      endIcon={<></>}
+    >
+      {m.components_newsPage_cards_common_writeCommentCard_done()}
+    </CustomButton>
   );
 };


### PR DESCRIPTION
If the comment is empty while editing the comment (project page, news feed, collab questions, all comments) the "Fertig" button should be disabled

Closes #234 